### PR TITLE
Fix Fozen Hash

### DIFF
--- a/app/models/bit_core/slide.rb
+++ b/app/models/bit_core/slide.rb
@@ -29,7 +29,7 @@ module BitCore
     private
 
     def update_slide_positions
-      slideshow
+      slideshow.reload
         .sort(slideshow.slide_ids)
     end
   end

--- a/spec/models/bit_core/slideshow_spec.rb
+++ b/spec/models/bit_core/slideshow_spec.rb
@@ -40,5 +40,17 @@ module BitCore
         expect(slideshow.slides.find(slide3.id).position).to eq(1)
       end
     end
+
+    describe "when a slideshow has many slides" do
+      before do
+        expect(slideshow.slides.count).to be > 0
+      end
+
+      it "can be deleted" do
+        expect do
+          slideshow.destroy
+        end.to change { BitCore::Slideshow.count }.by(-1)
+      end
+    end
   end
 end


### PR DESCRIPTION
- When deleting a slideshow the slideshow needs to be reloaded in order to delete associated slides
- `reload` prevents: "Can't modify frozen hash"

[#104572752]
