### PR TITLE
save slide options as a Hash

### DIFF
--- a/app/models/bit_core/audio_slide.rb
+++ b/app/models/bit_core/audio_slide.rb
@@ -2,6 +2,5 @@
 module BitCore
   # A Slide with audio content.
   class AudioSlide < Slide
-    serialize :options
   end
 end

--- a/app/models/bit_core/slide.rb
+++ b/app/models/bit_core/slide.rb
@@ -13,7 +13,10 @@ module BitCore
     validates :position, numericality: { greater_than_or_equal_to: 1 }
     validates :position, uniqueness: { scope: :bit_core_slideshow_id }
 
+    before_validation :normalize_options
     after_destroy :update_slide_positions
+
+    serialize :options
 
     def render_body
       return "" if body.nil?
@@ -28,6 +31,10 @@ module BitCore
     end
 
     private
+
+    def normalize_options
+      self.options = options.try(:to_h)
+    end
 
     def update_slide_positions
       slideshow.reload

--- a/app/models/bit_core/video_slide.rb
+++ b/app/models/bit_core/video_slide.rb
@@ -2,6 +2,5 @@
 module BitCore
   # A Slide with video content.
   class VideoSlide < Slide
-    serialize :options
   end
 end

--- a/spec/models/bit_core/slide_spec.rb
+++ b/spec/models/bit_core/slide_spec.rb
@@ -23,6 +23,27 @@ module BitCore
       end
     end
 
+    describe "when validated" do
+      context "if the options attribute is present" do
+        it "normalizes it" do
+          hashable = Struct.new("Hashable", :to_h).new("foo": "bar")
+          subject.options = hashable
+          subject.valid?
+
+          expect(subject.options).to eq("foo": "bar")
+        end
+      end
+
+      context "if the options attribute isn't present" do
+        it "leaves it as nil" do
+          subject.options = nil
+          subject.valid?
+
+          expect(subject.options).to be_nil
+        end
+      end
+    end
+
     describe "when destroyed" do
       let(:slideshow) { bit_core_slideshows(:slideshow1) }
       let(:slide) { bit_core_slides(:slide2) }


### PR DESCRIPTION
- otherwise they get saved as Parameters which is not forwards
  compatible (with Rails 5)
